### PR TITLE
Add Chrome extension for GPT-powered search & YouTube summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# gptPlugin
-chatgpt plugin for chrome
+# GPT Helper Chrome Extension
+
+This extension uses the OpenAI API to enhance Google search results and provide quick YouTube video summaries.
+
+## Features
+
+- **Google Search Integration** – When enabled in the options page, the extension sends your search query to the OpenAI API and displays the response above the search results.
+- **YouTube Summaries** – On YouTube video pages, a "Summarize Video" button appears near the title. Clicking it generates a summary via the OpenAI API.
+- **Options Page** – Set your OpenAI API key and toggle whether GPT results appear on Google search pages.
+
+## Setup
+
+1. Obtain an OpenAI API key.
+2. Run `Load unpacked` from Chrome's extensions page and select this folder.
+3. Open the extension's options page to enter your API key and desired settings.
+
+## Limitations
+
+This extension uses the OpenAI API directly. It does not support logging in with a ChatGPT Plus subscription.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,29 @@
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.action === 'askGPT') {
+    chrome.storage.sync.get(['apiKey'], async ({ apiKey }) => {
+      if (!apiKey) {
+        sendResponse({ error: 'No API key set' });
+        return;
+      }
+      try {
+        const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${apiKey}`
+          },
+          body: JSON.stringify({
+            model: 'gpt-3.5-turbo',
+            messages: [{ role: 'user', content: request.prompt }]
+          })
+        });
+        const data = await resp.json();
+        const answer = data.choices && data.choices[0] ? data.choices[0].message.content.trim() : '';
+        sendResponse({ answer });
+      } catch (e) {
+        sendResponse({ error: e.toString() });
+      }
+    });
+    return true; // async
+  }
+});

--- a/content.js
+++ b/content.js
@@ -1,0 +1,25 @@
+function addGPTBox(text) {
+  let box = document.getElementById('gpt-helper-result');
+  if (!box) {
+    box = document.createElement('div');
+    box.id = 'gpt-helper-result';
+    box.style.border = '1px solid #ddd';
+    box.style.padding = '10px';
+    box.style.margin = '10px 0';
+    box.style.background = '#f8f8f8';
+    const container = document.getElementById('rcnt');
+    if (container) container.prepend(box);
+  }
+  box.textContent = text;
+}
+
+chrome.storage.sync.get(['showSearch'], ({ showSearch }) => {
+  if (!showSearch) return;
+  const q = new URL(location.href).searchParams.get('q');
+  if (!q) return;
+  addGPTBox('Loading GPT result...');
+  chrome.runtime.sendMessage({ action: 'askGPT', prompt: q }, (resp) => {
+    if (resp && resp.answer) addGPTBox(resp.answer);
+    else addGPTBox(resp.error || 'Error fetching result');
+  });
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,29 @@
+{
+  "manifest_version": 3,
+  "name": "GPT Helper",
+  "description": "Use ChatGPT to enhance Google search and YouTube.",
+  "version": "0.1",
+  "permissions": ["storage", "activeTab", "scripting"],
+  "host_permissions": [
+    "https://api.openai.com/*",
+    "https://www.youtube.com/*",
+    "https://www.google.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "options.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://www.google.com/search*"],
+      "js": ["content.js"]
+    },
+    {
+      "matches": ["https://www.youtube.com/watch*"],
+      "js": ["youtube.js"]
+    }
+  ],
+  "options_page": "options.html"
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>GPT Helper Options</title>
+</head>
+<body>
+  <h1>GPT Helper Settings</h1>
+  <label>OpenAI API Key: <input type="password" id="key"></label><br>
+  <label><input type="checkbox" id="search"> Show GPT results on Google search</label><br>
+  <button id="save">Save</button>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,16 @@
+function load() {
+  chrome.storage.sync.get(['apiKey', 'showSearch'], ({ apiKey, showSearch }) => {
+    if (apiKey) document.getElementById('key').value = apiKey;
+    document.getElementById('search').checked = !!showSearch;
+  });
+}
+
+function save() {
+  const apiKey = document.getElementById('key').value.trim();
+  const showSearch = document.getElementById('search').checked;
+  chrome.storage.sync.set({ apiKey, showSearch });
+  alert('Saved');
+}
+
+document.getElementById('save').addEventListener('click', save);
+load();

--- a/youtube.js
+++ b/youtube.js
@@ -1,0 +1,29 @@
+function createButton() {
+  const btn = document.createElement('button');
+  btn.textContent = 'Summarize Video';
+  btn.style.marginLeft = '8px';
+  btn.addEventListener('click', summarize);
+  return btn;
+}
+
+function insertButton() {
+  const title = document.querySelector('#above-the-fold #title h1');
+  if (title && !document.getElementById('gpt-helper-btn')) {
+    const btn = createButton();
+    btn.id = 'gpt-helper-btn';
+    title.appendChild(btn);
+  }
+}
+
+async function summarize() {
+  const url = location.href;
+  const btn = document.getElementById('gpt-helper-btn');
+  if (btn) btn.textContent = 'Loading...';
+  chrome.runtime.sendMessage({ action: 'askGPT', prompt: `Summarize this video: ${url}` }, (resp) => {
+    if (btn) btn.textContent = 'Summarize Video';
+    if (resp && resp.answer) alert(resp.answer);
+    else alert(resp.error || 'Error fetching summary');
+  });
+}
+
+setInterval(insertButton, 2000);


### PR DESCRIPTION
## Summary
- create Chrome extension manifest and scripts
- add background service worker that queries OpenAI API
- inject GPT answers into Google search results when enabled
- provide YouTube video summarization button
- add options page and instructions in README

## Testing
- `npm --version`
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_6852b3cadd4c8333afcfed6671ff5088